### PR TITLE
fix discount_previdence_calculator.rb

### DIFF
--- a/lib/inss_calculator/discount_previdence_calculator.rb
+++ b/lib/inss_calculator/discount_previdence_calculator.rb
@@ -15,7 +15,7 @@ module InssCalculator
         SecondDiscountCalculator.new(salary).contribution,
         ThirdDiscountCalculator.new(salary).contribution,
         FourthDiscountCalculator.new(salary).contribution
-      ].reduce(:+).truncate(2)
+      ].reduce(:+).round(2)
     end
 
     def net_salary

--- a/spec/inss_calculator/discount_previdence_calculator_spec.rb
+++ b/spec/inss_calculator/discount_previdence_calculator_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe DiscountPrevidenceCalculator do
     end
 
     context 'when salary is 7786.02' do
-      it 'is 908.84' do
-        expect(described_class.new('7786.02').contribution).to eq(908.84)
+      it 'is 908.85' do
+        expect(described_class.new('7786.02').contribution).to eq(908.85)
       end
     end
   end


### PR DESCRIPTION
Round two decimals truncated partial results.
When salary is 7786.02 (the fourth limit), the previous result was 908.849999 before truncate it to 908.84. What is incorrect. The correct result is 908.85, the result of the partial sum between salary levels classes.
close #10 